### PR TITLE
Fix Decimal type JSON serialization error in database queries

### DIFF
--- a/utils/db.py
+++ b/utils/db.py
@@ -6,6 +6,7 @@ Konflux DevLake MCP Server - Database Connection Utility
 import json
 import logging
 from datetime import datetime, date
+from decimal import Decimal
 from typing import Any, Dict, Optional
 
 import pymysql
@@ -15,22 +16,29 @@ from utils.logger import get_logger, log_database_operation
 
 
 class DateTimeEncoder(json.JSONEncoder):
-    """Custom JSON encoder to handle datetime objects"""
-    
+    """Custom JSON encoder to handle datetime and Decimal objects"""
+
     def default(self, obj):
         if isinstance(obj, (datetime, date)):
             return obj.isoformat()
+        if isinstance(obj, Decimal):
+            # Convert Decimal to string to preserve precision
+            # Use str() instead of float() to avoid precision loss
+            return str(obj)
         return super().default(obj)
 
 
 def serialize_datetime_objects(data):
-    """Recursively serialize datetime objects in data structures"""
+    """Recursively serialize datetime and Decimal objects in data structures"""
     if isinstance(data, dict):
         return {key: serialize_datetime_objects(value) for key, value in data.items()}
     elif isinstance(data, list):
         return [serialize_datetime_objects(item) for item in data]
     elif isinstance(data, (datetime, date)):
         return data.isoformat()
+    elif isinstance(data, Decimal):
+        # Convert Decimal to string to preserve precision
+        return str(data)
     else:
         return data
 


### PR DESCRIPTION
Problem:
AI agent execution was failing with "Object of type Decimal is not JSON serializable" errors when executing SQL queries that returned aggregate functions (COUNT, AVG, SUM) or calculated percentages. This caused the agent to stop mid-analysis without completing reports.

Root Cause:
MySQL/PyMySQL returns numeric aggregate results as Python Decimal objects to preserve precision. The existing DateTimeEncoder and serialize_datetime_objects functions only handled datetime/date types, not Decimal types.

Solution:
- Updated DateTimeEncoder.default() to convert Decimal to string
- Updated serialize_datetime_objects() to handle Decimal types
- Used str(decimal) instead of float(decimal) to preserve precision

Impact:
- Eliminates JSON serialization errors in execute_query tool responses
- Allows AI agents to successfully complete multi-iteration analysis
- Preserves numeric precision for percentage and aggregate calculations

Testing:
Verified with test cases covering:
- DateTimeEncoder with nested Decimal objects
- serialize_datetime_objects with query result lists
- Full query response simulation matching actual DevLake queries