### PR TITLE
Add real-container TLS integration test and test-integration-tls Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,30 +1,57 @@
 # Makefile for Konflux DevLake MCP Server Test Suite
 
-.PHONY: help install install-dev test test-unit test-all test-file test-clean run run-http dev docker-build docker-run clean check-deps ci-quick ci quick-test watch-tests docs pre-commit test-parallel test-verbose test-debug test-performance test-integration test-e2e test-integration-setup test-integration-teardown setup-dev help-test
+.PHONY: help install install-dev test test-unit test-all test-file test-clean run run-http dev docker-build docker-run clean check-deps ci-quick ci quick-test watch-tests docs pre-commit test-parallel test-verbose test-debug test-performance test-integration test-integration-tls test-e2e test-integration-setup test-integration-teardown setup-dev help-test check-compose check-runtime
+
+# Container compose command (evaluated once): prefers `docker compose`, then
+# `docker-compose`, then `podman compose`, then `podman-compose`. Empty if
+# none are available on PATH.
+COMPOSE := $(shell \
+	if docker compose version >/dev/null 2>&1; then echo "docker compose"; \
+	elif command -v docker-compose >/dev/null 2>&1; then echo "docker-compose"; \
+	elif podman compose version >/dev/null 2>&1; then echo "podman compose"; \
+	elif command -v podman-compose >/dev/null 2>&1; then echo "podman-compose"; \
+	fi)
+
+# Raw container runtime (no compose), for starting standalone containers -
+# e.g. the TLS-enforcing MySQL container managed directly by pytest rather
+# than via compose. Empty if neither is available on PATH.
+RUNTIME := $(shell command -v docker >/dev/null 2>&1 && echo docker || { command -v podman >/dev/null 2>&1 && echo podman; })
+
+check-compose:
+	@if [ -z "$(COMPOSE)" ]; then \
+		echo "❌ No docker compose / docker-compose / podman compose / podman-compose found on PATH"; \
+		exit 1; \
+	fi
+
+check-runtime:
+	@if [ -z "$(RUNTIME)" ]; then \
+		echo "❌ Neither docker nor podman found on PATH"; \
+		exit 1; \
+	fi
 
 # Default target
-help:
+help: ## Show this help message
 	@echo "Konflux DevLake MCP Server - Development Commands"
 	@echo "=================================================="
 	@echo ""
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
 # Installation and setup
-install:
+install: ## Install production dependencies
 	pip install -r requirements.txt
 
-install-dev:
+install-dev: ## Install dependencies plus dev/test tooling
 	pip install -r requirements.txt
 	pip install pytest-cov pytest-timeout pytest-xdist
 
 # Testing commands
-test-unit:
+test-unit: ## Run unit tests (mocked DB, no containers required)
 	python run_tests.py --unit --verbose
 
-test-integration:
+test-integration: check-compose ## Run integration tests (requires docker/podman, auto setup/teardown)
 	@echo "🚀 Starting integration tests with database setup..."
 	@echo "📦 Starting MySQL database..."
-	@docker compose up -d mysql || docker-compose up -d mysql
+	@$(COMPOSE) up -d mysql
 	@echo "✅ Database container started"
 	@echo "⏳ Waiting for database to be ready..."
 	@sleep 25
@@ -32,11 +59,27 @@ test-integration:
 	@python run_tests.py --integration --verbose; \
 	TEST_RESULT=$$?; \
 	echo "🧹 Cleaning up database..."; \
-	docker compose down -v || docker-compose down -v; \
+	$(COMPOSE) down -v; \
 	echo "✅ Database cleaned up"; \
 	exit $$TEST_RESULT
 
-test-e2e:
+test-integration-tls: check-compose check-runtime ## Run MySQL TLS integration tests (require_secure_transport=ON, requires docker/podman compose, plus docker or podman)
+	@echo "🔐 Starting MySQL TLS integration tests..."
+	@echo "📦 Starting non-TLS MySQL database (for the regression check)..."
+	@$(COMPOSE) up -d mysql
+	@echo "✅ Database container started"
+	@echo "⏳ Waiting for database to be ready..."
+	@sleep 25
+	@echo "🧪 Running TLS integration tests..."
+	@echo "ℹ️  A second, TLS-enforcing MySQL container is started/stopped automatically by the tests"
+	@CONTAINER_RUNTIME=$(RUNTIME) python -m pytest tests/integration/test_mysql_tls_integration.py -m integration -vv --tb=short; \
+	TEST_RESULT=$$?; \
+	echo "🧹 Cleaning up database..."; \
+	$(COMPOSE) down -v; \
+	echo "✅ Database cleaned up"; \
+	exit $$TEST_RESULT
+
+test-e2e: check-compose ## Run LLM end-to-end tests (requires GEMINI_API_KEY)
 	@echo "🤖 Running LLM E2E tests..."
 	@{ \
 	  if [ -n "$$E2E_TEST_MODELS" ]; then \
@@ -58,26 +101,26 @@ test-e2e:
 		echo "❌ No LLM API keys set. Set GEMINI_API_KEY."; \
 		exit 1; \
 	fi
-	@docker compose up -d mysql || docker-compose up -d mysql
+	@$(COMPOSE) up -d mysql
 	@echo "✅ Database container started"
 	@echo "⏳ Waiting for database to be ready..."
 	@sleep 25
 	@echo "🧪 Initializing database (via container mysql client)..."
-	@docker compose exec -T mysql mysql -uroot -ptest_password -e "DROP DATABASE IF EXISTS lake; CREATE DATABASE lake;"
-	@docker compose exec -T mysql mysql -uroot -ptest_password lake < testdata/mysql/01-schema.sql
-	@docker compose exec -T mysql mysql -uroot -ptest_password lake < testdata/mysql/02-test-data.sql
+	@$(COMPOSE) exec -T mysql mysql -uroot -ptest_password -e "DROP DATABASE IF EXISTS lake; CREATE DATABASE lake;"
+	@$(COMPOSE) exec -T mysql mysql -uroot -ptest_password lake < testdata/mysql/01-schema.sql
+	@$(COMPOSE) exec -T mysql mysql -uroot -ptest_password lake < testdata/mysql/02-test-data.sql
 	@echo "🧪 Running tests (stdio by default)..."
 	@LITELLM_LOGGING=0 LITELLM_DISABLE_LOGGING=1 LITELLM_VERBOSE=0 LITELLM_LOGGING_QUEUE=0 pytest tests/e2e -vv --maxfail=1 --tb=short; \
 	TEST_RESULT=$$?; \
 	echo "🧹 Cleaning up database..."; \
-	docker compose down -v || docker-compose down -v; \
+	$(COMPOSE) down -v; \
 	echo "✅ Database cleaned up"; \
 	exit $$TEST_RESULT
 
-test-all:
+test-all: check-compose ## Run unit + integration + e2e tests
 	@echo "🚀 Running comprehensive test suite..."
 	@echo "📦 Starting MySQL database..."
-	@docker compose up -d mysql || docker-compose up -d mysql
+	@$(COMPOSE) up -d mysql
 	@echo "✅ Database container started"
 	@echo "⏳ Waiting for database to be ready..."
 	@sleep 35
@@ -85,7 +128,7 @@ test-all:
 	@python run_tests.py --all --verbose; \
 	CORE_RESULT=$$?; \
 	echo "🧹 Cleaning up database..."; \
-	docker compose down -v || docker-compose down -v; \
+	$(COMPOSE) down -v; \
 	echo "✅ Database cleaned up"; \
 	if [ $$CORE_RESULT -ne 0 ]; then \
 		echo "❌ Core tests failed"; \
@@ -101,34 +144,35 @@ test-all:
 	echo ""; \
 	echo "✅ All tests passed"
 
-# Docker commands
-docker-build: ## Build Docker image
-	docker build -t konflux-devlake-mcp .
+# Container image commands
+docker-build: check-runtime ## Build container image
+	@$(RUNTIME) build -t konflux-devlake-mcp .
 
-docker-run: ## Run Docker container
-	docker run -p 3000:3000 konflux-devlake-mcp
+docker-run: check-runtime ## Run container image
+	@$(RUNTIME) run -p 3000:3000 konflux-devlake-mcp
 
 # Utility commands
-test-clean:
+test-clean: ## Clean test artifacts and cache
 	python run_tests.py --clean
 
-check-deps:
+check-deps: ## Check if test dependencies are installed
 	python run_tests.py --check-deps
 
 # Environment setup
-setup-dev: install-dev
+setup-dev: install-dev ## Install dev dependencies and prepare local environment
 	@echo "Development environment setup complete"
 	@echo "Run 'make test' to verify everything is working"
 
 # Help for specific commands
-help-test:
+help-test: ## Show detailed testing command reference
 	@echo "Testing Commands:"
 	@echo ""
 	@echo "  Unit Tests (Tests tool logic and parameter validation):"
 	@echo "    test-unit        - Unit tests only"
 	@echo ""
 	@echo "  Integration Tests (Tests tool functionality against a SQL database):"
-	@echo "    test-integration - Integration tests (requires docker engine to be running, auto setup/teardown)"
+	@echo "    test-integration     - Integration tests (requires docker/podman compose, auto setup/teardown)"
+	@echo "    test-integration-tls - MySQL TLS (require_secure_transport=ON) tests (requires docker/podman compose, plus docker or podman)"
 	@echo ""
 	@echo "  E2E Tests (Tests tool functionality using a LLM):"
 	@echo "    test-e2e         - E2E tests with LLM integration"

--- a/tests/integration/test_mysql_tls_integration.py
+++ b/tests/integration/test_mysql_tls_integration.py
@@ -1,0 +1,221 @@
+"""
+MySQL TLS integration tests.
+
+These tests exercise the opt-in TLS support (ssl_enabled / ssl_ca_path) in
+KonfluxDevLakeConnection against a real MySQL instance that enforces
+`require_secure_transport=ON`, proving that:
+  - a connection without TLS enabled is rejected by the server, and
+  - a connection with a correct CA bundle succeeds with real certificate
+    verification (no CERT_NONE / check_hostname=False shortcuts).
+
+A dedicated, ephemeral MySQL container is started for this module (separate
+from the docker-compose `mysql` service used by the rest of the integration
+suite, which has no TLS enforcement). The container runtime is taken from
+the CONTAINER_RUNTIME env var (set by `make test-integration-tls`'s
+$(RUNTIME) so Make and pytest agree on the same tool), falling back to
+detecting `docker` then `podman` on PATH for standalone `pytest` runs.
+"""
+
+import datetime
+import ipaddress
+import os
+import shutil
+import socket
+import subprocess
+import time
+
+import pytest
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+
+from utils.db import KonfluxDevLakeConnection
+
+CONTAINER_NAME = "devlake-mcp-test-mysql-tls"
+ROOT_PASSWORD = "test_password"
+DB_NAME = "lake"
+DB_USER = "devlake"
+DB_PASSWORD = "devlake_password"
+COMMON_NAME = "127.0.0.1"
+
+
+def _container_runtime():
+    """Return the path to a usable container runtime CLI, or None.
+
+    Honors CONTAINER_RUNTIME if set (e.g. by `make test-integration-tls`),
+    otherwise detects docker/podman directly on PATH.
+    """
+    preferred = os.environ.get("CONTAINER_RUNTIME")
+    if preferred:
+        return shutil.which(preferred)
+    return shutil.which("docker") or shutil.which("podman")
+
+
+def _free_tcp_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _generate_self_signed_cert(cert_path, key_path):
+    """Generate a self-signed cert/key pair usable as both server cert and CA."""
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    subject = issuer = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, COMMON_NAME)])
+    now = datetime.datetime.now(datetime.timezone.utc)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - datetime.timedelta(minutes=5))
+        .not_valid_after(now + datetime.timedelta(days=1))
+        .add_extension(
+            x509.SubjectAlternativeName([x509.IPAddress(ipaddress.ip_address(COMMON_NAME))]),
+            critical=False,
+        )
+        .sign(key, hashes.SHA256())
+    )
+
+    key_path.write_bytes(
+        key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.TraditionalOpenSSL,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+    )
+    key_path.chmod(0o644)
+    cert_path.write_bytes(cert.public_bytes(serialization.Encoding.PEM))
+    cert_path.chmod(0o644)
+
+
+@pytest.fixture(scope="module")
+def tls_certs(tmp_path_factory):
+    """Self-signed cert/key pair, also usable as the client CA bundle."""
+    certs_dir = tmp_path_factory.mktemp("mysql-tls-certs")
+    cert_path = certs_dir / "server-cert.pem"
+    key_path = certs_dir / "server-key.pem"
+    _generate_self_signed_cert(cert_path, key_path)
+    return {"dir": certs_dir, "cert": cert_path, "key": key_path}
+
+
+@pytest.fixture(scope="module")
+def tls_mysql_container(tls_certs):
+    """Start a MySQL container that enforces require_secure_transport=ON."""
+    runtime = _container_runtime()
+    if runtime is None:
+        pytest.skip("No container runtime (docker/podman) available on PATH")
+
+    port = _free_tcp_port()
+    subprocess.run([runtime, "rm", "-f", CONTAINER_NAME], capture_output=True, check=False)
+
+    run_cmd = [
+        runtime,
+        "run",
+        "-d",
+        "--name",
+        CONTAINER_NAME,
+        "-p",
+        f"{port}:3306",
+        "-e",
+        f"MYSQL_ROOT_PASSWORD={ROOT_PASSWORD}",
+        "-e",
+        f"MYSQL_DATABASE={DB_NAME}",
+        "-e",
+        f"MYSQL_USER={DB_USER}",
+        "-e",
+        f"MYSQL_PASSWORD={DB_PASSWORD}",
+        "-v",
+        f"{tls_certs['dir']}:/certs:ro",
+        "mysql:8.0",
+        "--default-authentication-plugin=mysql_native_password",
+        "--require_secure_transport=ON",
+        "--ssl-ca=/certs/server-cert.pem",
+        "--ssl-cert=/certs/server-cert.pem",
+        "--ssl-key=/certs/server-key.pem",
+    ]
+    result = subprocess.run(run_cmd, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        pytest.fail(f"Could not start TLS-enforcing MySQL container: {result.stderr}")
+
+    try:
+        _wait_for_container_ready(runtime)
+        yield {"host": COMMON_NAME, "port": port}
+    finally:
+        subprocess.run([runtime, "rm", "-f", CONTAINER_NAME], capture_output=True, check=False)
+
+
+def _wait_for_container_ready(runtime, max_retries=30, retry_delay=2):
+    """Wait for MySQL to accept connections via the (TLS-exempt) local socket."""
+    ping_cmd = [
+        runtime,
+        "exec",
+        CONTAINER_NAME,
+        "mysqladmin",
+        "ping",
+        "-h",
+        "localhost",
+        "-uroot",
+        f"-p{ROOT_PASSWORD}",
+    ]
+    for _ in range(max_retries):
+        result = subprocess.run(ping_cmd, capture_output=True, text=True, check=False)
+        if result.returncode == 0:
+            return
+        time.sleep(retry_delay)
+
+    pytest.fail(f"TLS-enforcing MySQL container did not become ready after {max_retries} attempts")
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+class TestMySQLTLSIntegration:
+    """Integration tests for opt-in TLS support against a TLS-enforcing server."""
+
+    async def test_connection_without_tls_setting_fails(self, tls_mysql_container):
+        """A server enforcing require_secure_transport must reject plain TCP."""
+        connection = KonfluxDevLakeConnection(
+            {
+                "host": tls_mysql_container["host"],
+                "port": tls_mysql_container["port"],
+                "user": DB_USER,
+                "password": DB_PASSWORD,
+                "database": DB_NAME,
+            }
+        )
+
+        result = await connection.connect()
+
+        assert result["success"] is False
+        await connection.close()
+
+    async def test_connection_with_correct_ca_succeeds(self, tls_mysql_container, tls_certs):
+        """A connection with the matching CA bundle must succeed over TLS."""
+        connection = KonfluxDevLakeConnection(
+            {
+                "host": tls_mysql_container["host"],
+                "port": tls_mysql_container["port"],
+                "user": DB_USER,
+                "password": DB_PASSWORD,
+                "database": DB_NAME,
+                "ssl_enabled": True,
+                "ssl_ca_path": str(tls_certs["cert"]),
+            }
+        )
+
+        result = await connection.connect()
+
+        assert result["success"] is True
+        assert "version" in result
+
+        healthy = await connection.test_connection()
+        assert healthy is True
+
+        await connection.close()
+
+    async def test_existing_non_tls_database_unaffected(self, integration_db_connection):
+        """The default docker-compose MySQL (no TLS enforcement) must still
+        work fine when ssl_enabled is left unset."""
+        assert await integration_db_connection.test_connection() is True


### PR DESCRIPTION
## Summary

This PR originally proposed opt-in TLS support for the MySQL connection, but #80 merged an equivalent feature (`ssl_enabled`/`ssl_ca_path` config fields, `DB_SSL`/`DB_SSL_CA` env vars) with unit test coverage while this branch was in flight. Rebased on top of `main` (which now includes #80), this PR is scoped down to what's still missing:

- **`tests/integration/test_mysql_tls_integration.py`**: a real-container integration test. Starts an ephemeral MySQL container (`docker`, falling back to `podman`) with a generated self-signed cert and `--require_secure_transport=ON`, then proves:
  - a connection with `ssl_enabled` unset/false is rejected by the server (real enforcement, not a mock)
  - a connection with `ssl_enabled=True` and the correct `ssl_ca_path` succeeds, with real certificate verification (no `CERT_NONE`/`check_hostname=False` shortcuts)
  - the existing non-TLS docker-compose MySQL is unaffected when TLS is left disabled
- **`make test-integration-tls`**: runs the above locally/in CI. Fails fast with a clear message if no usable container tooling is on `PATH`.
- Makefile cleanup found while wiring the above up:
  - Fills in missing `## ` doc-comments on existing targets so `make help` actually lists them (previously only 2 of 13 targets showed up).
  - Replaces the repeated `docker compose X || docker-compose X` pattern across every target with a single `COMPOSE` variable (computed once) that tries `docker compose`, `docker-compose`, `podman compose`, and `podman-compose` in order, plus a `check-compose`/`check-runtime` prerequisite that fails clearly when nothing usable is found.
  - `docker-build`/`docker-run` now use the same `RUNTIME` variable instead of hardcoding `docker`.
  - The Makefile's resolved `RUNTIME` is threaded into the TLS integration test via a `CONTAINER_RUNTIME` env var, so Make's detection and pytest's own container management agree on the same tool instead of duplicating/potentially disagreeing.
  - Fixed `test-e2e`'s database-init steps to fall back to `docker-compose` when the `docker` CLI isn't on `PATH` (every other `up`/`down` call in the file already did this; the `exec` calls used for e2e DB setup didn't).

## Test plan

- [x] `black --line-length 100` / `flake8` clean
- [x] `make test-unit` — 427/427 passing
- [x] `make test-integration-tls` run end-to-end against real `docker`/`podman` containers (verified with both `docker-compose` and native `podman compose` as the resolved `$(COMPOSE)` tool)
- [x] Verified `RUNTIME`/`COMPOSE` variable resolution in isolation across docker-only, podman-only, and docker+podman environments