### PR TITLE
Update codecov.yml: add ignore patterns for non-code files

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -33,6 +33,12 @@ ignore:
   - "docs/"
   - "k8s/"
   - "testdata/"
+  - ".agents/**"
+  - ".claude/**"
+  - ".cursor/**"
+  - "skills/**"
+  - "*.md"
+  - "*.toml"
 
 comment:
   layout: "reach,diff,flags,files,footer"


### PR DESCRIPTION
## Summary

Adds ignore patterns for non-executable files that inflate the coverage denominator:

- `.agents/**` — AI agent configurations
- `.claude/**` — Claude AI workspace settings
- `.cursor/**` — Cursor AI settings
- `skills/**` — AI skill definitions
- `*.md` — Markdown files
- `*.toml` — TOML configuration files

Existing ignore patterns (tests, venv, docs, k8s, testdata, etc.) are preserved.

## Why

Non-executable files are counted as "uncovered lines" by Codecov, dragging down patch coverage even though they can't be tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)